### PR TITLE
Fixed Issue #4

### DIFF
--- a/src/main/java/mc/carlton/freerpg/miscEvents/PlayerCraft.java
+++ b/src/main/java/mc/carlton/freerpg/miscEvents/PlayerCraft.java
@@ -48,7 +48,7 @@ public class PlayerCraft implements Listener {
         CraftingRecipes craftingRecipes = new CraftingRecipes();
         ItemStack[] craftingMatrix = e.getInventory().getMatrix();
         ArrayList<Material> crafting = new ArrayList<>();
-        for (int i=0; i<9;i++) {
+        for (int i=0; i<craftingMatrix.getAmount();i++) {
             if (craftingMatrix[i] == null) {
                 crafting.add(Material.AIR);
             }


### PR DESCRIPTION
Fixed issue where a ArrayOutOfBounds Exception occurs when a player
crafts in a 2x2 crafting grid. Changed it so the for statement will only
recurse through the size of the crafting grid, rather than a predefined
size.