### PR TITLE
Fix complete hijacking of the fishing rod

### DIFF
--- a/src/main/java/mc/carlton/freerpg/miscEvents/PlayerFish.java
+++ b/src/main/java/mc/carlton/freerpg/miscEvents/PlayerFish.java
@@ -54,9 +54,6 @@ public class PlayerFish implements Listener {
             if (pAbilities[4] == -2) {
                 fishingClass.superBait(e.getHook(),caughtThing,world);
             }
-            else {
-                fishingClass.normalCatch(e.getHook(),caughtThing,world);
-            }
         }
         else if (e.getState() == PlayerFishEvent.State.CAUGHT_ENTITY) {
             Fishing fishingClass = new Fishing(p);

--- a/src/main/java/mc/carlton/freerpg/perksAndAbilities/Fishing.java
+++ b/src/main/java/mc/carlton/freerpg/perksAndAbilities/Fishing.java
@@ -218,20 +218,6 @@ public class Fishing extends Skill{
 
     }
 
-    public void normalCatch(FishHook fishhook, Entity hookedEntity,World world) {
-        if (!runMethods) {
-            return;
-        }
-        if (hookedEntity == null) {
-            return;
-        }
-        if (hookedEntity instanceof Item) {
-            ItemStack drop = dropTable(false);
-            ((Item) hookedEntity).setItemStack(drop);
-
-        }
-    }
-
     public void fishPersonStart() {
         if (!runMethods) {
             return;


### PR DESCRIPTION
The way it is now prevents other plugins from modifying fishing drops. Its better to do nothing than it would be to have a fake hardcoded vanilla drop